### PR TITLE
Updating AWS sdk libraries to latest in Ant

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,11 +22,11 @@
 
     <target name="download">
         <mkdir dir="${external.dir}/lib"/>
-        
-        <get src= "http://central.maven.org/maven2/com/amazonaws/amazon-kinesis-client/1.4.0/amazon-kinesis-client-1.4.0.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
-        <get src= "http://central.maven.org/maven2/com/amazonaws/amazon-kinesis-connectors/1.2.0/amazon-kinesis-connectors-1.2.0.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+
+        <get src= "http://central.maven.org/maven2/com/amazonaws/amazon-kinesis-client/1.9.3/amazon-kinesis-client-1.9.3.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/com/amazonaws/amazon-kinesis-connectors/1.3.0/amazon-kinesis-connectors-1.3.0.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
         <get src= "http://central.maven.org/maven2/com/google/protobuf/protobuf-java/2.6.1/protobuf-java-2.6.1.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
-        <get src= "http://central.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
         <get src= "http://central.maven.org/maven2/org/apache/lucene/lucene-core/4.8.1/lucene-core-4.8.1.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
     	<get src= "http://central.maven.org/maven2/commons-codec/commons-codec/1.10/commons-codec-1.10.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
     	<get src= "http://central.maven.org/maven2/com/ning/async-http-client/1.9.30/async-http-client-1.9.30.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
@@ -37,20 +37,23 @@
     	
         <get src= "http://central.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
 
-        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.3.2/jackson-core-2.3.2.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
-        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.3.2/jackson-databind-2.3.2.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
-        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.6.4/jackson-annotations-2.6.4.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.9.8/jackson-core-2.9.8.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.9.8/jackson-databind-2.9.8.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.9.8/jackson-annotations-2.9.8.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
+        <get src= "http://central.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.9.8/jackson-dataformat-cbor-2.9.8.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
 
         <get src= "http://central.maven.org/maven2/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true"/>
 
-        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.10.77/aws-java-sdk-1.10.77.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
-        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.10.77/aws-java-sdk-core-1.10.77.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
-        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-kinesis/1.10.77/aws-java-sdk-kinesis-1.10.77.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
-        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-cloudwatch/1.10.77/aws-java-sdk-cloudwatch-1.10.77.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
-        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-dynamodb/1.10.77/aws-java-sdk-dynamodb-1.10.77.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.11.534/aws-java-sdk-1.11.534.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-core/1.11.534/aws-java-sdk-core-1.11.534.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-kinesis/1.11.534/aws-java-sdk-kinesis-1.11.534.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-cloudwatch/1.11.534/aws-java-sdk-cloudwatch-1.11.534.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-dynamodb/1.11.534/aws-java-sdk-dynamodb-1.11.534.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
 
-        <get src= "http://central.maven.org/maven2/org/apache/httpcomponents/httpclient/4.3.5/httpclient-4.3.5.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
-        <get src= "http://central.maven.org/maven2/org/apache/httpcomponents/httpcore/4.3.2/httpcore-4.3.2.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/org/json/json/20180813/json-20180813.jar" dest="${external.dir}/lib" />
+
+        <get src= "http://central.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.8/httpclient-4.5.8.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
+        <get src= "http://central.maven.org/maven2/org/apache/httpcomponents/httpcore/4.4.11/httpcore-4.4.11.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
 
         <get src= "http://central.maven.org/maven2/joda-time/joda-time/2.10.1/joda-time-2.10.1.jar" dest="${external.dir}/lib" usetimestamp="true" verbose="true" />
 

--- a/src/main/java/com/sumologic/client/CloudWatchMessageModelSumologicTransformer.java
+++ b/src/main/java/com/sumologic/client/CloudWatchMessageModelSumologicTransformer.java
@@ -3,9 +3,9 @@ package com.sumologic.client;
 import java.io.IOException;
 
 import com.amazonaws.services.kinesis.model.Record;
-import com.amazonaws.util.json.JSONArray;
-import com.amazonaws.util.json.JSONException;
-import com.amazonaws.util.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import com.sumologic.client.implementations.SumologicTransformer;
 import com.sumologic.client.model.CloudWatchLogsMessageModel;
 import com.sumologic.client.model.LogEvent;

--- a/src/main/java/com/sumologic/kinesis/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/sumologic/kinesis/KinesisConnectorRecordProcessor.java
@@ -13,7 +13,7 @@ import com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
 import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
 import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
 import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;


### PR DESCRIPTION
* Updated each of the aws-sdk libraries to current versions.  This required adding/updating other libraries as well because of incompatibilities and deprecations