### PR TITLE
Using AWS Credentials Chain

### DIFF
--- a/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
+++ b/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
@@ -53,7 +53,7 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
             String msg = "Could not load properties file " + configFile + " from classpath";
             throw new IllegalStateException(msg, e);
         }
-        this.config = new KinesisConnectorForSumologicConfiguration(properties, getAWSCredentialsProvider());
+        this.config = new KinesisConnectorForSumologicConfiguration(properties, getAWSCredentialsProvider(configFile));
         
         LOG.info("Using " + configFile);
 
@@ -71,13 +71,13 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
      * 
      * @return
      */
-    public AWSCredentialsProvider getAWSCredentialsProvider() {
+    public AWSCredentialsProvider getAWSCredentialsProvider(String configFile) {
         return new AWSCredentialsProviderChain(
             new EnvironmentVariableCredentialsProvider(),
             new SystemPropertiesCredentialsProvider(),
             new ProfileCredentialsProvider(),
             new EC2ContainerCredentialsProviderWrapper(),
-            new ClasspathPropertiesFileCredentialsProvider("SumologicConnector.properties")
+            new ClasspathPropertiesFileCredentialsProvider(configFile)
         );
     }
 

--- a/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
+++ b/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
@@ -7,13 +7,9 @@ import java.util.Properties;
 import org.apache.log4j.Logger;
 
 import com.sumologic.client.KinesisConnectorForSumologicConfiguration;
-import com.sumologic.client.SumologicMessageModelPipeline;
-import com.sumologic.client.model.SimpleKinesisMessageModel;
-import com.sumologic.kinesis.KinesisConnectorExecutorBase;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
+import com.amazonaws.auth.*;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
-import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
 
 /**
  * This class defines the execution of a Amazon Kinesis Connector.
@@ -76,7 +72,13 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
      * @return
      */
     public AWSCredentialsProvider getAWSCredentialsProvider() {
-        return new ClasspathPropertiesFileCredentialsProvider("SumologicConnector.properties");
+        return new AWSCredentialsProviderChain(
+            new EnvironmentVariableCredentialsProvider(),
+            new SystemPropertiesCredentialsProvider(),
+            new ProfileCredentialsProvider(),
+            new EC2ContainerCredentialsProviderWrapper(),
+            new ClasspathPropertiesFileCredentialsProvider("SumologicConnector.properties")
+        );
     }
 
     /**


### PR DESCRIPTION
This solves https://github.com/SumoLogic/sumologic-kinesis-connector/issues/12

It now uses the AWSCredentialsProviderChain instead of only looking in a file.  This allows using ENV vars, or roles on EC2 and ECS instances.
This is the same flow as the Default Chain except that as the final link, it looks in the SumologicConnector.properties file.

I also removed some unused import statements