### PR TITLE
Optionally use the environment for config instead of properties files

### DIFF
--- a/src/main/java/com/sumologic/client/SumologicExecutor.java
+++ b/src/main/java/com/sumologic/client/SumologicExecutor.java
@@ -11,6 +11,10 @@ public class SumologicExecutor extends
 		KinesisConnectorExecutor<SimpleKinesisMessageModel, String> {
 	private static String defaultConfigFile = "SumologicConnector.properties";
 
+	public SumologicExecutor() {
+		super();
+	}
+
 	/**
 	 * SumologicExecutor constructor.
 	 * 
@@ -37,29 +41,41 @@ public class SumologicExecutor extends
 		ArrayList<String> configFiles = new ArrayList<String>();
 		ArrayList<Thread> executorThreads = new ArrayList<Thread>();
 
+		Boolean use_env = false;
+
 		for (String arg : args) {
 			if (arg.endsWith(".properties")) {
 				configFiles.add(arg);
+			} else if (arg.equals("use-env")) {
+				use_env = true;
 			}
 		}
 
-		// if none of the arguments contained a config file, try the default
-		// file name
-		if (configFiles.size() == 0) {
-			configFiles.add(defaultConfigFile);
-		}
-
-		for (String configFile : configFiles) {
-
-			KinesisConnectorExecutor<SimpleKinesisMessageModel, String> sumologicExecutor = new SumologicExecutor(
-					configFile);
+		if (use_env) {
+			KinesisConnectorExecutor<SimpleKinesisMessageModel, String> sumologicExecutor = new SumologicExecutor();
 
 			Thread executorThread = new Thread(sumologicExecutor);
 			executorThreads.add(executorThread);
 			executorThread.start();
+
+		} else {
+			// if none of the arguments contained a config file, try the default
+			// file name
+			if (configFiles.size() == 0) {
+				configFiles.add(defaultConfigFile);
+			}
+
+			for (String configFile : configFiles) {
+				KinesisConnectorExecutor<SimpleKinesisMessageModel, String> sumologicExecutor = new SumologicExecutor(
+						configFile);
+
+				Thread executorThread = new Thread(sumologicExecutor);
+				executorThreads.add(executorThread);
+				executorThread.start();
+			}
 		}
 
-		for(Thread executorThread : executorThreads){
+		for (Thread executorThread : executorThreads) {
 			executorThread.join();
 		}
 	}

--- a/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
+++ b/src/main/java/com/sumologic/kinesis/KinesisConnectorExecutor.java
@@ -31,6 +31,22 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
     protected final KinesisConnectorForSumologicConfiguration config;
     private final Properties properties;
 
+    public KinesisConnectorExecutor() {
+        // Load ENV vars into properties
+        LOG.info("Using ENV vars for properties");
+
+        properties = new Properties();
+        System.getenv().forEach(properties::setProperty);
+
+        this.config = new KinesisConnectorForSumologicConfiguration(properties, getAWSCredentialsProvider());
+
+        // Send sample data to AWS Kinesis if specified in the properties file
+        setupInputStream();
+
+        // Initialize executor with configurations
+        super.initialize((KinesisConnectorConfiguration)config);
+    }
+
     /**
      * Create a new KinesisConnectorExecutor based on the provided configuration (*.propertes) file.
      * 
@@ -71,6 +87,10 @@ public abstract class KinesisConnectorExecutor<T, U> extends KinesisConnectorExe
      * 
      * @return
      */
+    public AWSCredentialsProvider getAWSCredentialsProvider() {
+        return new DefaultAWSCredentialsProviderChain();
+    }
+
     public AWSCredentialsProvider getAWSCredentialsProvider(String configFile) {
         return new AWSCredentialsProviderChain(
             new EnvironmentVariableCredentialsProvider(),


### PR DESCRIPTION
Using ENV vars is more conducive to running in Docker.  If we need to run multiple streams in the same app, then properties files will need to be used.

If we want to run a single stream, it's now possible to use ENV variables for our config instead of specifying properties.  This allows us to build the code, and execute with different config in multiple docker containers.